### PR TITLE
Non-optional encoding API

### DIFF
--- a/Base58Swift.podspec
+++ b/Base58Swift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Base58Swift"
-  s.version      = "2.0.0"
+  s.version      = "2.1.0"
   s.summary      = "A pure swift implementation of base58 string encoding and decoding."
   s.description  = <<-DESC
   A pure swift implementation of base58 string encoding and decoding. Based off of https://github.com/jbenet/go-base58.
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage      = "https://github.com/keefertaylor/Base58Swift"
   s.license       = { :type => "MIT", :file => "LICENSE" }
   s.author        = { "Keefer Taylor" => "keefer@keefertaylor.com" }
-  s.source        = { :git => "https://github.com/keefertaylor/Base58Swift.git", :tag => "2.0.0" }
+  s.source        = { :git => "https://github.com/keefertaylor/Base58Swift.git", :tag => "2.1.0" }
   s.source_files  = "Base58Swift/*.swift"
   s.swift_version = "4.2"
   s.ios.deployment_target = "8.0"

--- a/Base58Swift/Base58.swift
+++ b/Base58Swift/Base58.swift
@@ -16,7 +16,7 @@ public enum Base58 {
   /// Encode the given bytes into a Base58Check encoded string.
   /// - Parameter bytes: The bytes to encode.
   /// - Returns: A base58check encoded string representing the given bytes, or nil if encoding failed.
-  public static func base58CheckEncode(_ bytes: [UInt8]) -> String? {
+  public static func base58CheckEncode(_ bytes: [UInt8]) -> String {
     let checksum = calculateChecksum(bytes)
     let checksummedBytes = bytes + checksum
     return Base58.base58Encode(checksummedBytes)
@@ -43,7 +43,7 @@ public enum Base58 {
   /// Encode the given bytes to a Base58 encoded string.
   /// - Parameter bytes: The bytes to encode.
   /// - Returns: A base58 encoded string representing the given bytes, or nil if encoding failed.
-  public static func base58Encode(_ bytes: [UInt8]) -> String? {
+  public static func base58Encode(_ bytes: [UInt8]) -> String {
     var answer: [UInt8] = []
     var integerBytes = BigUInt(Data(bytes))
 
@@ -56,7 +56,10 @@ public enum Base58 {
     let prefix = Array(bytes.prefix { $0 == 0 }).map { _ in alphabet[0] }
     answer.insert(contentsOf: prefix, at: 0)
 
-    return String(bytes: answer, encoding: String.Encoding.utf8)
+    // swiftlint:disable force_unwrapping
+    // Force unwrap as the given alphabet will always decode to UTF8. 
+    return String(bytes: answer, encoding: String.Encoding.utf8)!
+    // swiftlint:enable force_unwrapping
   }
 
   /// Decode the given base58 encoded string to bytes.

--- a/Base58SwiftTests/Base58Tests.swift
+++ b/Base58SwiftTests/Base58Tests.swift
@@ -37,10 +37,7 @@ class Base58SwiftTests: XCTestCase {
   public func testBase58EncodingForValidStrings() {
     for (decoded, encoded) in validStringDecodedToEncodedTuples {
       let bytes = [UInt8](decoded.utf8)
-      guard let result = Base58.base58Encode(bytes) else {
-        XCTFail()
-        return
-      }
+      let result = Base58.base58Encode(bytes)
       XCTAssertEqual(result, encoded)
     }
   }
@@ -68,11 +65,7 @@ class Base58SwiftTests: XCTestCase {
       6, 161, 159, 136, 34, 110, 33, 238, 14, 79, 14, 218, 133, 13, 109, 40, 194, 236, 153, 44, 61, 157, 254
     ]
     let expectedOutput = "tz1Y3qqTg9HdrzZGbEjiCPmwuZ7fWVxpPtRw"
-
-    guard let actualOutput = Base58.base58CheckEncode(inputData) else {
-      XCTFail()
-      return
-    }
+    let actualOutput = Base58.base58CheckEncode(inputData)
     XCTAssertEqual(actualOutput, expectedOutput)
   }
 


### PR DESCRIPTION
Use a non-optional API to encode strings. 

Encoding to utf8 will never fail given the restricted alphabet being used.  