### PR TITLE
Adding patch for strings with leading 1s and test

### DIFF
--- a/Base58Swift/Base58.swift
+++ b/Base58Swift/Base58.swift
@@ -79,7 +79,10 @@ public enum Base58 {
     }
 
     let bytes = answer.serialize()
-    return Array(byteString.prefix { i in i == alphabet[0] }) + bytes
+    // For every leading one on the input we need to add a leading 0 on the output
+    let leadingOnes = byteString.prefix(while: { value in value == alphabet[0]})
+    let leadingZeros: [UInt8] = Array(repeating: 0, count: leadingOnes.count)
+    return leadingZeros + bytes
   }
 
   /// Calculate a checksum for a given input by hashing twice and then taking the first four bytes.

--- a/Base58SwiftTests/Base58Tests.swift
+++ b/Base58SwiftTests/Base58Tests.swift
@@ -82,6 +82,32 @@ class Base58SwiftTests: XCTestCase {
     XCTAssertEqual(actualOutput, expectedOutputData)
   }
 
+  public func testBase58CheckDecodingLeadingOne() {
+    let inputString = "1CdPoF9cvw3YEiuRCHxdsGpvb5tSUYBBo"
+    let expectedOutputData: [UInt8] = [
+      0, 2, 50, 244, 121, 42, 5, 10, 13, 224, 245, 201, 20, 55, 55, 148, 92, 255, 84, 36, 4
+    ]
+    guard let actualOutput = Base58.base58CheckDecode(inputString) else {
+      XCTFail()
+      return
+    }
+    XCTAssertEqual(actualOutput, expectedOutputData)
+    
+  }
+    
+  public func testDecodeLeadingOnes() {
+    let inputString = "11111111111111111111111111111111"
+    let expectedOutputData: [UInt8] = [
+      0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+    ]
+    
+    guard let actualOutput = Base58.base58Decode(inputString) else {
+      XCTFail()
+      return
+    }
+    XCTAssertEqual(actualOutput, expectedOutputData)
+  }
+
   public func testBase58CheckDecodingWithInvalidCharacters() {
     XCTAssertNil(Base58.base58CheckDecode("0oO1lL"))
   }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/attaswift/BigInt.git",
         "state": {
           "branch": null,
-          "revision": "018a5925f60f9e0523edd261de394a0898fe95b7",
-          "version": "3.1.0"
-        }
-      },
-      {
-        "package": "SipHash",
-        "repositoryURL": "https://github.com/attaswift/SipHash",
-        "state": {
-          "branch": null,
-          "revision": "e325083424688055363bbfcb7f1a440d7d7a1bae",
-          "version": "1.2.2"
+          "revision": "889a1ecacd73ccc189c5cb29288048f186c44ed9",
+          "version": "5.2.1"
         }
       }
     ]


### PR DESCRIPTION
applies https://github.com/keefertaylor/Base58Swift/issues/25 into this local fork, fixing an issue with ignored data when decoding a string into data